### PR TITLE
Move Typing Classes

### DIFF
--- a/binary_search.py
+++ b/binary_search.py
@@ -1,16 +1,6 @@
-from abc import abstractmethod
-from typing import Protocol, TypeVar, Any, Sequence
+from typing import Sequence
 
-
-class ComparableProtocol(Protocol):
-    @abstractmethod
-    def __lt__(self, other: Any) -> bool: ...
-
-    @abstractmethod
-    def __eq__(self, other: Any) -> bool: ...
-
-
-Comparable = TypeVar('Comparable', bound=ComparableProtocol)
+from local_typing import Comparable
 
 
 def binary_search(sequence: Sequence[Comparable], target: Comparable) -> int | None:

--- a/local_typing.py
+++ b/local_typing.py
@@ -1,0 +1,16 @@
+from abc import abstractmethod
+from typing import Protocol, TypeVar, Any
+
+
+class __ComparableProtocol(Protocol):
+    @abstractmethod
+    def __lt__(self, other: Any) -> bool: ...
+
+    @abstractmethod
+    def __eq__(self, other: Any) -> bool: ...
+
+    @abstractmethod
+    def __gt__(self, other: Any) -> bool: ...
+
+
+Comparable = TypeVar('Comparable', bound=__ComparableProtocol)

--- a/selection_sort.py
+++ b/selection_sort.py
@@ -1,13 +1,6 @@
-from abc import abstractmethod
-from typing import Protocol, TypeVar, Any, MutableSequence
+from typing import MutableSequence
 
-
-class ComparableProtocol(Protocol):
-    @abstractmethod
-    def __lt__(self, other: Any) -> bool: ...
-
-
-Comparable = TypeVar('Comparable', bound=ComparableProtocol)
+from local_typing import Comparable
 
 
 def selection_sort(sequence: MutableSequence[Comparable]) -> None:


### PR DESCRIPTION
Resolve #5

Класс `Comparable` теперь опредён в файле `local_typing.py`

# Подробности реализации
Было принято решение определить один единственный класс `Comparable`, который требует реализации операций `<`, `==` и `>`. Деления на классы, поддерживающие разные комбинации этих операций не были созданы, чтобы избежать дальнейшей путаницы в будущем.